### PR TITLE
feat: add --no-cache flag to bypass success cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ gh log-ci
   --api-timeout <secs>   Max seconds per API request (default: 30; env LOG_CI_API_TIMEOUT)
   --watch                Continuously poll and update commit statuses
   --watch-interval <s>   Seconds between polls in watch mode (default: 10; env LOG_CI_WATCH_INTERVAL)
+  --no-cache             Ignore success cache, force fresh API calls for all commits
   --help, -h          Show help / usage
   --version           Show version
 ```
@@ -56,6 +57,7 @@ Options:
   --api-timeout <secs>   Max seconds per API request (default: 30; env LOG_CI_API_TIMEOUT)
   --help, -h          Show this help text
   --version           Show version
+  --no-cache             Ignore success cache, force fresh API calls for all commits
 
 ```
 
@@ -139,6 +141,7 @@ gh auth login
 - API request timeout: `--api-timeout <secs>` (default 30) or `LOG_CI_API_TIMEOUT`.
 - Watch mode: `--watch` continuously refresh; `--watch-interval <s>` (default 10) or `LOG_CI_WATCH_INTERVAL`.
 - Success cache (success-only): TTL `LOG_CI_CACHE_TTL` (default 86400s / 24h); directory `LOG_CI_CACHE_DIR` (default ~/.cache/gh-log-ci); debug `LOG_CI_CACHE_DEBUG=1`.
+- Cache bypass: `--no-cache` to force fresh API calls for all commits.
 
 ## Limitations
 - One REST API call per commit (future: GraphQL batch).
@@ -148,7 +151,6 @@ gh auth login
 - Assumes `origin` remote name.
 
 ## Roadmap
-- Add a flag to force refresh (ignore cache), e.g. `--no-cache`.
 - Accessibility: `--no-emoji`, `--no-color` respecting `NO_COLOR`.
 - Rate-limit handling with backoff + user notice.
 - Commit age column (e.g., `2h ago`).
@@ -221,6 +223,7 @@ Early MVP; expect changes as features mature.
 
 | Version | Date | Notes |
 |---------|------|-------|
+| 0.5.0 | 2025-11-04 | Add --no-cache flag to bypass success cache and force fresh API calls |
 | 0.4.1 | 2025-10-23 | Success-only caching (TTL, dir config, debug env) skips API calls for cached successes |
 | 0.4.0 | 2025-10-22 | Watch mode (`--watch`, `--watch-interval`); refactored core for repeated polling |
 | 0.3.4 | 2025-10-22 | Progress-aware spinner (`--no-spinner`) option (shows completed/total); per-request `--api-timeout` with ⏲ icon on timeout |

--- a/gh-log-ci
+++ b/gh-log-ci
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PROGRAM="gh log-ci"
-VERSION="0.4.1"
+VERSION="0.5.0"
 
 show_help() {
   cat <<'EOF'
@@ -12,17 +12,18 @@ gh log-ci - show CI status next to recent commits
 Usage:
   gh log-ci [options] [<branch>]
 
-Options:
-  --branch <name>        Branch to inspect (alternative to positional <branch>)
-  --limit, -n <n>        Number of commits to display (default: 15; env LOG_CI_LIMIT overrides)
-  --concurrency, -c <n>  Max parallel API calls (default: 4; env LOG_CI_CONCURRENCY overrides)
-  --checks, -C           Show per-check run summaries beneath each commit (env LOG_CI_SHOW_CHECKS=1)
-  --no-spinner           Disable loading spinner (env LOG_CI_NO_SPINNER=1)
-  --api-timeout <secs>   Max seconds per API request (default: 30; env LOG_CI_API_TIMEOUT)
-  --watch                Continuously poll and update commit statuses
-  --watch-interval <s>   Seconds between polls in watch mode (default: 10; env LOG_CI_WATCH_INTERVAL)
-  --help, -h             Show this help text
-  --version              Show version
+ Options:
+   --branch <name>        Branch to inspect (alternative to positional <branch>)
+   --limit, -n <n>        Number of commits to display (default: 15; env LOG_CI_LIMIT overrides)
+   --concurrency, -c <n>  Max parallel API calls (default: 4; env LOG_CI_CONCURRENCY overrides)
+   --checks, -C           Show per-check run summaries beneath each commit (env LOG_CI_SHOW_CHECKS=1)
+   --no-spinner           Disable loading spinner (env LOG_CI_NO_SPINNER=1)
+   --api-timeout <secs>   Max seconds per API request (default: 30; env LOG_CI_API_TIMEOUT)
+   --watch                Continuously poll and update commit statuses
+   --watch-interval <s>   Seconds between polls in watch mode (default: 10; env LOG_CI_WATCH_INTERVAL)
+   --no-cache             Ignore success cache, force fresh API calls for all commits
+   --help, -h             Show this help text
+   --version              Show version
 
 Branch auto-detect order when <branch> not supplied:
   1. GitHub default branch (via gh repo view)
@@ -63,6 +64,7 @@ WATCH_INTERVAL="${LOG_CI_WATCH_INTERVAL:-10}"
 CACHE_TTL="${LOG_CI_CACHE_TTL:-86400}" # seconds (default 24h)
 CACHE_DIR="${LOG_CI_CACHE_DIR:-$HOME/.cache/gh-log-ci}"
 CACHE_DEBUG="${LOG_CI_CACHE_DEBUG:-0}"
+NO_CACHE=0
 
 # Parse flags
 POS_ARGS=()
@@ -91,6 +93,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --watch-interval)
       WATCH_INTERVAL="${2:-}"; shift || true
+      ;;
+    --no-cache)
+      NO_CACHE=1
       ;;
     -h|--help)
       show_help; exit 0
@@ -269,8 +274,8 @@ run_once() {
   pids=()
   for i in $(seq 0 $((TOTAL-1))); do
     SHA="${SHA_MAP[$i]}"
-    # Cache hit: if commit is cached success and not showing checks, skip API
-    if [[ -n "${SUCCESS_CACHE[$SHA]:-}" && "$SHOW_CHECKS" != "1" ]]; then
+    # Cache hit: if commit is cached success and not showing checks and --no-cache not set, skip API
+    if [[ -n "${SUCCESS_CACHE[$SHA]:-}" && "$SHOW_CHECKS" != "1" && "$NO_CACHE" != "1" ]]; then
       if [[ "$CACHE_DEBUG" == "1" ]]; then
         echo "[cache hit] $SHA" >&2
       fi

--- a/tests/cache_success.bats
+++ b/tests/cache_success.bats
@@ -25,4 +25,23 @@ setup() {
   run "$SCRIPT" --limit 1 --branch "$BRANCH"
   [ "$status" -eq 0 ]
   [[ "$output" == *"$SHORT_SHA"* ]]
+  [[ "$output" == *"[cache hit]"* ]]
+}
+
+@test "ignores cache when --no-cache flag is used" {
+  export LOG_CI_CACHE_DEBUG=1
+  FULL_SHA=$(git rev-parse HEAD)
+  SHORT_SHA=$(git rev-parse --short HEAD)
+  TS=$(date +%s)
+  REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+  OWNER="unknown"; REPO="unknown"
+  if [[ "$REMOTE_URL" =~ github.com[:/]([^/]+)/([^/]+)(\.git)?$ ]]; then
+    OWNER="${BASH_REMATCH[1]}"; REPO="${BASH_REMATCH[2]}"; REPO="${REPO%.git}"
+  fi
+  CACHE_FILE="$LOG_CI_CACHE_DIR/${OWNER}_${REPO}_success.cache"
+  echo -e "$FULL_SHA\t$TS" > "$CACHE_FILE"
+  run "$SCRIPT" --limit 1 --branch "$BRANCH" --no-cache
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$SHORT_SHA"* ]]
+  [[ "$output" != *"[cache hit]"* ]]
 }


### PR DESCRIPTION
## Summary
- Add --no-cache flag that forces fresh API calls for all commits
- Skip cache logic when flag is set, ensuring all commits get fresh CI status
- Update help text and documentation
- Add tests for the new functionality
- Update README configuration section and roadmap
- Bump version to 0.5.0

This implements the first item in the roadmap: "Add a flag to force refresh (ignore cache), e.g. \`--no-cache\`"

## Testing
The new functionality is covered by a new test case that verifies:
1. Cache is used normally when flag is not set
2. Cache is ignored when --no-cache flag is used

All existing tests continue to pass.