### PR TITLE
⚡ Bolt: Optimize GraphQL TSV parsing with O(1) lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-10-23 - Avoid grep in loops for O(N*M) performance penalty
+**Learning:** Calling `grep` or similar process-spawning filtering tools inside loops over large datasets creates a significant O(N*M) performance penalty, especially in single-threaded bash scripts processing TSV or API outputs.
+**Action:** Parse data once outside the loop into an associative array for O(1) lookups instead.

--- a/gh-log-ci
+++ b/gh-log-ci
@@ -385,15 +385,6 @@ transform_graphql_response_commit() {
   ' <<< "$response" 2>/dev/null || true
 }
 
-# T016: Group TSV lines by commit SHA for aggregation
-group_by_sha() {
-  local tsv_data="$1"
-  local sha="$2"
-
-  # Extract lines for specific SHA
-  grep "^${sha}" <<< "$tsv_data" | cut -f2- || true
-}
-
 run_once() {
   INDEX=0
   declare -A LINE_MAP
@@ -560,6 +551,19 @@ run_once() {
       echo "[GraphQL] Success - processing $(echo "$GRAPHQL_TSV" | wc -l) check runs" >&2
     fi
 
+    # Pre-process GraphQL TSV into associative array for O(1) lookup
+    declare -A SHA_RAW_LINES
+    if [[ -n "$GRAPHQL_TSV" ]]; then
+      while IFS=$'\t' read -r G_SHA G_NAME G_STATUS G_CONCLUSION G_EXCLUDED; do
+        if [[ -z "$G_SHA" ]]; then continue; fi
+        if [[ -n "${SHA_RAW_LINES[$G_SHA]:-}" ]]; then
+          SHA_RAW_LINES[$G_SHA]+=$'\n'"$G_NAME"$'\t'"$G_STATUS"$'\t'"$G_CONCLUSION"$'\t'"$G_EXCLUDED"
+        else
+          SHA_RAW_LINES[$G_SHA]="$G_NAME"$'\t'"$G_STATUS"$'\t'"$G_CONCLUSION"$'\t'"$G_EXCLUDED"
+        fi
+      done <<< "$GRAPHQL_TSV"
+    fi
+
     # Process each commit with GraphQL data
     for i in $(seq 0 $((TOTAL-1))); do
             SHA="${SHA_MAP[$i]}"
@@ -575,7 +579,7 @@ run_once() {
             fi
 
             # Extract check runs for this commit from GraphQL TSV
-            RAW_LINES=$(group_by_sha "$GRAPHQL_TSV" "$SHA")
+            RAW_LINES="${SHA_RAW_LINES[$SHA]:-}"
 
             # T021: Aggregate status using existing logic
             success_count=0; fail_count=0; cancel_count=0; pending_count=0; other_count=0; total_count=0


### PR DESCRIPTION
💡 What: Refactored `gh-log-ci` to eliminate the `group_by_sha` function which used `grep` and `cut` inside a loop. Instead, the GraphQL TSV output is pre-processed once into an associative array (`SHA_RAW_LINES`) mapping SHAs to their check run data for O(1) lookups.

🎯 Why: In the previous implementation, every commit iteratively invoked subshells (`grep` and `cut`) over potentially large strings, creating an O(N*M) performance bottleneck. This was especially slow for repos with many commits and check suites.

📊 Impact: Significantly speeds up the processing loop for aggregated check runs, reducing shell sub-process overhead to near-zero and vastly improving execution times for larger datasets.

🔬 Measurement: Run the script over a repository with a large number of commits (`--limit 100`). The aggregation phase should feel noticeably quicker than before.

---
*PR created automatically by Jules for task [9875926492477171457](https://jules.google.com/task/9875926492477171457) started by @xpepper*