### PR TITLE
⚡ Bolt: Replace O(N*M) grep inside loop with O(N) associative array lookup

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -42,7 +42,7 @@
 - **GraphQL functions**: Lines 221-290 handle batch query, transformation, and grouping
   - `fetch_checks_graphql()`: Execute GraphQL batch query with timeout
   - `transform_graphql_response()`: Convert nested JSON to TSV format
-  - `group_by_sha()`: Extract check runs for specific commit SHA
+  - Parses GraphQL TSV into an associative array for O(1) commit data lookups (eliminates `group_by_sha` O(N*M) lookup)
   - `fetch_checks_graphql_commit()`: Execute GraphQL query for single commit (lines 293-334)
   - `transform_graphql_response_commit()`: Convert single commit JSON to TSV format (lines 336-348)
 - **Cache management**: Lines 310-323 read cache with TTL validation

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-24 - [Avoid grep in loops for O(N*M) lookups]
+**Learning:** Using grep/cut to extract specific elements from a dataset string iteratively inside a loop causes an O(N*M) bottleneck, which is particularly severe when parsing a single large bulk-fetched TSV into individual commit segments.
+**Action:** Parse dataset strings into associative arrays before the loop. This changes the O(N*M) text search into an O(N) array buildup + O(1) loop iteration lookup, maximizing Bash text processing performance.

--- a/gh-log-ci
+++ b/gh-log-ci
@@ -385,15 +385,6 @@ transform_graphql_response_commit() {
   ' <<< "$response" 2>/dev/null || true
 }
 
-# T016: Group TSV lines by commit SHA for aggregation
-group_by_sha() {
-  local tsv_data="$1"
-  local sha="$2"
-
-  # Extract lines for specific SHA
-  grep "^${sha}" <<< "$tsv_data" | cut -f2- || true
-}
-
 run_once() {
   INDEX=0
   declare -A LINE_MAP
@@ -560,6 +551,20 @@ run_once() {
       echo "[GraphQL] Success - processing $(echo "$GRAPHQL_TSV" | wc -l) check runs" >&2
     fi
 
+    # Pre-process GraphQL TSV into an associative array for O(1) lookups
+    declare -A GRAPHQL_DATA_MAP
+    if [[ -n "$GRAPHQL_TSV" ]]; then
+      while IFS=$'\t' read -r G_SHA G_REST; do
+        if [[ -n "$G_SHA" ]]; then
+          if [[ -z "${GRAPHQL_DATA_MAP[$G_SHA]:-}" ]]; then
+            GRAPHQL_DATA_MAP[$G_SHA]="$G_REST"
+          else
+            GRAPHQL_DATA_MAP[$G_SHA]+=$'\n'"$G_REST"
+          fi
+        fi
+      done <<< "$GRAPHQL_TSV"
+    fi
+
     # Process each commit with GraphQL data
     for i in $(seq 0 $((TOTAL-1))); do
             SHA="${SHA_MAP[$i]}"
@@ -574,8 +579,8 @@ run_once() {
               continue
             fi
 
-            # Extract check runs for this commit from GraphQL TSV
-            RAW_LINES=$(group_by_sha "$GRAPHQL_TSV" "$SHA")
+            # Extract check runs for this commit from pre-processed map
+            RAW_LINES="${GRAPHQL_DATA_MAP[$SHA]:-}"
 
             # T021: Aggregate status using existing logic
             success_count=0; fail_count=0; cancel_count=0; pending_count=0; other_count=0; total_count=0


### PR DESCRIPTION
### 💡 What:
Replaced the `group_by_sha` function, which spawned `grep` and `cut` inside a loop for every single commit, with a single pre-processing step that parses the bulk GraphQL TSV dataset into a native Bash associative array (`GRAPHQL_DATA_MAP`). This turns an O(N*M) search operation into an O(N) setup followed by an O(1) lookup.

### 🎯 Why:
Iteratively calling `grep` within a loop creates a severe O(N*M) performance bottleneck, as new subprocesses are spawned repeatedly to scan the entire TSV response string.

### 📊 Impact:
Massive reduction in script execution time (eliminates hundreds of subprocess executions when parsing large payloads) and significantly lower CPU overhead. Lookups are now an instant O(1) memory access.

### 🔬 Measurement:
Run the script natively against a repository with heavy CI load. The processing phase after the GraphQL fetch completes will now execute near-instantaneously compared to before.

---
*PR created automatically by Jules for task [3330776909665800692](https://jules.google.com/task/3330776909665800692) started by @xpepper*