### PR TITLE
⚡ Bolt: [performance improvement] Optimize GraphQL response grouping with associative arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Avoid grep inside loops for data processing
+**Learning:** Avoid calling `grep` or similar filtering tools inside loops over large datasets (O(N*M)) as spawning subprocesses within a loop degrades performance. Bash 4 associative arrays are a more efficient way to process data.
+**Action:** Parse data once into associative arrays for O(1) lookups whenever processing nested or grouping relationships within a dataset.

--- a/gh-log-ci
+++ b/gh-log-ci
@@ -385,15 +385,6 @@ transform_graphql_response_commit() {
   ' <<< "$response" 2>/dev/null || true
 }
 
-# T016: Group TSV lines by commit SHA for aggregation
-group_by_sha() {
-  local tsv_data="$1"
-  local sha="$2"
-
-  # Extract lines for specific SHA
-  grep "^${sha}" <<< "$tsv_data" | cut -f2- || true
-}
-
 run_once() {
   INDEX=0
   declare -A LINE_MAP
@@ -560,6 +551,21 @@ run_once() {
       echo "[GraphQL] Success - processing $(echo "$GRAPHQL_TSV" | wc -l) check runs" >&2
     fi
 
+    # Optimization: Parse TSV into associative array once (O(M)) instead of grep in loop (O(N*M))
+    declare -A GRAPHQL_GROUPED
+    if [[ -n "$GRAPHQL_TSV" ]]; then
+      while IFS=$'\t' read -r G_SHA G_NAME G_STATUS G_CONCLUSION G_EXCLUDED; do
+        if [[ -n "$G_SHA" ]]; then
+          LINE="${G_NAME}"$'\t'"${G_STATUS}"$'\t'"${G_CONCLUSION}"$'\t'"${G_EXCLUDED}"
+          if [[ -n "${GRAPHQL_GROUPED[$G_SHA]:-}" ]]; then
+            GRAPHQL_GROUPED[$G_SHA]+=$'\n'"$LINE"
+          else
+            GRAPHQL_GROUPED[$G_SHA]="$LINE"
+          fi
+        fi
+      done <<< "$GRAPHQL_TSV"
+    fi
+
     # Process each commit with GraphQL data
     for i in $(seq 0 $((TOTAL-1))); do
             SHA="${SHA_MAP[$i]}"
@@ -574,8 +580,8 @@ run_once() {
               continue
             fi
 
-            # Extract check runs for this commit from GraphQL TSV
-            RAW_LINES=$(group_by_sha "$GRAPHQL_TSV" "$SHA")
+            # Extract check runs for this commit from pre-parsed associative array O(1) lookup
+            RAW_LINES="${GRAPHQL_GROUPED[$SHA]:-}"
 
             # T021: Aggregate status using existing logic
             success_count=0; fail_count=0; cancel_count=0; pending_count=0; other_count=0; total_count=0


### PR DESCRIPTION
💡 What: Refactored the way `gh-log-ci` parses and extracts GraphQL test result responses per commit. Instead of using `grep` within a loop to filter results (O(N*M)), the logic now parses the TSV directly into an associative array (O(M)), allowing O(1) loop-ups.
🎯 Why: Inside the `run_once` loop over `TOTAL` commits, the script was invoking `group_by_sha` on each iteration. This spawned a `grep` and a `cut` subprocess each time. Subprocesses in bash are slow, and searching a large TSV multiple times leads to noticeable overhead.
📊 Impact: Expected to significantly reduce execution time and CPU overhead when parsing larger limit bounds (-n limit), particularly eliminating subprocess initialization bottlenecks. Time complexity goes from O(N*M) to O(N+M).
🔬 Measurement: Verify the improvement by running the tool via `./gh-log-ci -n 50` and comparing total execution time with and without the patch. The bats test suite ensures no loss of original behavior.

Also logged this insight to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [1871129198044812694](https://jules.google.com/task/1871129198044812694) started by @xpepper*